### PR TITLE
Fix obnoxious warnings when using pyflakes.vim on an unnamed file.

### DIFF
--- a/pyflakes/checker.py
+++ b/pyflakes/checker.py
@@ -184,7 +184,9 @@ class Checker(object):
     nodeDepth = 0
     traceTree = False
 
-    def __init__(self, tree, filename='(none)'):
+    def __init__(self, tree, filename=None):
+        if filename is None:
+            filename = '(none)'
         self._deferredFunctions = []
         self._deferredAssignments = []
         self.dead_scopes = []


### PR DESCRIPTION
pyflakes.vim passes None as the filename if the file is unnamed, we must ensure that it gets replaced to '(none)' otherwise functions like os.path.basename fail.
