### PR TITLE
setup.py: use setuptools instead of distutils.core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # (c) 2005-2009 Divmod, Inc.  See LICENSE file for details
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name="pyflakes",


### PR DESCRIPTION
adds ability to use "python setup.py develop"
