### PR TITLE
tag things with '# pyflakes.ignore'

### DIFF
--- a/pyflakes/scripts/pyflakes.py
+++ b/pyflakes/scripts/pyflakes.py
@@ -54,10 +54,21 @@ def check(codeString, filename):
         # Okay, it's syntactically valid.  Now check it.
         w = checker.Checker(tree, filename)
         w.messages.sort(lambda a, b: cmp(a.lineno, b.lineno))
+        warnings = 0
         for warning in w.messages:
+            if skip_warning(warning):
+                continue
             print warning
-        return len(w.messages)
+            warnings += 1
+        return warnings
 
+def skip_warning(warning):
+    # quick dirty hack, just need to keep the line in the warning
+    line = open(warning.filename).readlines()[warning.lineno-1]
+    return skip_line(line)
+
+def skip_line(line):
+    return line.rstrip().endswith('# pyflakes.ignore')
 
 def checkPath(filename):
     """


### PR DESCRIPTION
One of my uses cases for pyflakes is integrating into a testing/build system. As a result i found it necessary to have a way of skipping certain things that I'm choosing are "ok" to get to a point where i can enforce a "no warnings before deploy" type of rule.

(the specific warnings that i wanted to skip don't matter so much here, just that i needed that ability; mostly it was things where i had conditional re-imports or purposefully unused imports)

This change allows me to add a comment at the end of any python line which i want pyflakes to ignore.

```
... # pyflakes.ignore
```
