### PR TITLE
don't issue Unused Variables warning when using locals() in current scope

### DIFF
--- a/NEWS.txt
+++ b/NEWS.txt
@@ -1,3 +1,6 @@
+0.4.1 (xxx):
+  - Don't issue Unused Variable warning when using locals() in current scope
+
 0.4.0 (2009-11-25):
   - Fix reporting for certain SyntaxErrors which lack line number
     information.

--- a/pyflakes/test/test_other.py
+++ b/pyflakes/test/test_other.py
@@ -202,6 +202,29 @@ class TestUnusedAssignment(harness.Test):
         ''', m.UnusedVariable)
 
 
+    def test_unusedVariable_asLocals(self):
+        """
+        Using locals() it is perfectly valid to have unused variables
+        """
+        self.flakes('''
+        def a():
+            b = 1
+            return locals()
+        ''')
+
+    def test_unusedVariable_noLocals(self):
+        """
+        Using locals() in wrong scope should not matter
+        """
+        self.flakes('''
+        def a():
+            locals()
+            def a():
+                b = 1
+                return
+        ''', m.UnusedVariable)
+
+
     def test_assignToGlobal(self):
         """
         Assigning to a global and then not using that global is perfectly


### PR DESCRIPTION
Superseeds #24.

Note that currently if it detects a locals() call in current scope, it will disable any unused variables messages in that scope. There are some rare cases when this is not desired, as shown in #24. Those are hard to catch though ;)
